### PR TITLE
Potential fix for code scanning alert no. 2: Code injection

### DIFF
--- a/.github/workflows/tag-on-hacs-version.yml
+++ b/.github/workflows/tag-on-hacs-version.yml
@@ -50,11 +50,12 @@ jobs:
         run: |
           VERSION=$(jq -r .version version.json)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Check if tag exists
         id: check
         run: |
-          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
             echo "Tag already exists"
             echo "tag_exists=true" >> $GITHUB_OUTPUT
           else
@@ -65,8 +66,8 @@ jobs:
         if: steps.check.outputs.tag_exists == 'false'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ steps.version.outputs.version }}
-          name: v${{ steps.version.outputs.version }}
+          tag_name: v$VERSION
+          name: v$VERSION
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Potential fix for [https://github.com/evandepol/dropdown-list-badge/security/code-scanning/2](https://github.com/evandepol/dropdown-list-badge/security/code-scanning/2)

To fix the issue, the best approach is to use an intermediate environment variable to store the untrusted input (`steps.version.outputs.version`) and reference it using proper shell syntax (`"$VAR"`) instead of directly embedding it in the vulnerable `run:` or `with:` blocks. Additionally, ensure that shell metacharacters and special characters in the variable are properly escaped or sanitized, preventing potential injection.

Steps to implement the fix:
1. Replace all instances of `v${{ steps.version.outputs.version }}` with a safely referenced environment variable in shell syntax, e.g., `"$VERSION"`.
2. Set the environment variable during the step using `$GITHUB_ENV` or inline `env:` in the YAML.
3. Ensure all vulnerable contexts (e.g., `run:` and `with:` blocks) reference the environment variable safely.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
