### PR TITLE
Potential fix for code scanning alert no. 4: Expression injection in Actions

### DIFF
--- a/.github/workflows/tag-on-hacs-version.yml
+++ b/.github/workflows/tag-on-hacs-version.yml
@@ -26,9 +26,12 @@ jobs:
           fetch-depth: 0  # Required to access tags
 
       - name: Download workflow run commit
+        env:
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          git fetch origin ${{ github.event.workflow_run.head_branch }}
-          git checkout ${{ github.event.workflow_run.head_sha }}
+          git fetch origin "$BRANCH"
+          git checkout "$SHA"
 
       - name: Check if version.json changed
         id: version_changed


### PR DESCRIPTION
Potential fix for [https://github.com/evandepol/dropdown-list-badge/security/code-scanning/4](https://github.com/evandepol/dropdown-list-badge/security/code-scanning/4)

To mitigate the risk of expression injection, the untrusted input `${{ github.event.workflow_run.head_branch }}` should be assigned to an intermediate environment variable. The environment variable can then be safely accessed using shell syntax (`$VAR`) instead of GitHub Actions syntax (`${{ env.VAR }}`) within the command. This approach ensures that the workflow adheres to best practices and prevents code injection vulnerabilities.

#### Implementation steps:
1. Modify the `run` step on line 29 to use an environment variable for `github.event.workflow_run.head_branch`.
2. Reference the environment variable using shell syntax (`$BRANCH`) in the command.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
